### PR TITLE
Always use tmp in codes/tenant/main.go

### DIFF
--- a/codes/tenant/main.go
+++ b/codes/tenant/main.go
@@ -45,10 +45,12 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	//! [telepresence]
-	certDir := filepath.Join(os.TempDir(), "k8s-webhook-server", "serving-certs")
+	certDir := filepath.Join("tmp", "k8s-webhook-server", "serving-certs")
 	root := os.Getenv("TELEPRESENCE_ROOT")
 	if len(root) != 0 {
 		certDir = filepath.Join(root, certDir)
+	} else {
+		certDir = filepath.Join("/", certDir)
 	}
 	//! [telepresence]
 


### PR DESCRIPTION
## WHY
The result of `os.TempDir()` differes depending on the execution environment.

For example, on macOS it will return a string like `/var/folders/32/***/T/`.
cf. https://golang.org/pkg/os/
cf. https://apple.stackexchange.com/questions/94964/where-is-the-temp-folder#:~:text=OS%20X%20generates%20a%20programmatic,stored%20by%20the%20Applications%20running.

The example is shown below.

```go
// main.go
package main

import (
        "fmt"
        "os"
)

func main() {
        fmt.Printf("The result of os.TempDir(): %s\n", os.TempDir())
}
```

```console
$ go run main.go
The result of os.TempDir(): /var/folders/**/***/T/

$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.15.7
BuildVersion:   19H114
```

In `codes/tenant/main.go`, `os.TempDir()` is used to construct a directory name, but it does not work as intended on macOS for the above reasons.

## WHAT
Updated `codes/tenant/main.go`. Now, it always use `tmp` as the directory name, and works well on macOS.