### PR TITLE
Specify container name explicity when using telepresence

### DIFF
--- a/docs/kubebuilder/debug.md
+++ b/docs/kubebuilder/debug.md
@@ -35,7 +35,7 @@ Kubebuilderで生成したカスタムコントローラでは、Webhookの証�
 最後に下記のコマンドで、Kubernetes上で動いているコントローラをローカルで動いているプロセスと置き換えます。
 
 ```console
-telepresence --namespace tenant-system --swap-deployment tenant-controller-manager --run make run
+telepresence --namespace tenant-system --swap-deployment tenant-controller-manager:manager --run make run
 ```
 
 なお、kubebuilderが生成したコントローラのマニフェスト(`config/manager/manager.yaml`)には以下のように非常に小さなサイズのResourcesが指定されています。


### PR DESCRIPTION
## WHY
When I followed the documentation below, I noticed that `$ telepresence --swap-deployment DEPLOYMENT_NAME` did not work as intended.
https://zoetrope.github.io/kubebuilder-training/kubebuilder/debug.html

The cause was that the wrong container was selected for swapping. `kube-rbac-proxy` was mistakenly swapped, although `manager` should have been selected. These two containers are shown below.

```console
$ kubectl get deployment tenant-controller-manager -n tenant-system -o yaml | grep -A2 ' image:'
        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
        imagePullPolicy: IfNotPresent
        name: kube-rbac-proxy
--
        image: controller:v1
        imagePullPolicy: IfNotPresent
        name: manager
```

With `$ telepresence --swap-deployment DEPLOYMENT_NAME:CONTAINER`, we can explicitly specify the container name. By using this option, I was able to solve the above problem.

```console
$ telepresence --version
0.105

$ telepresence --help
.
.
.
  --swap-deployment DEPLOYMENT_NAME[:CONTAINER], -s DEPLOYMENT_NAME[:CONTAINER]
                        Swap out an existing deployment with the Telepresence proxy, swap back on exit. If there are multiple containers in the pod then add the optional container name to indicate
                        which container to use.
```

Updating the documentation will help others avoid similar problems in the future.

## WHAT
Updated the document to explicitly specify the container name.
