### PR TITLE
Fix typo kubebuilder markers

### DIFF
--- a/codes/markdown-view/api/v1/markdownview_types.go
+++ b/codes/markdown-view/api/v1/markdownview_types.go
@@ -27,8 +27,7 @@ type MarkdownViewSpec struct {
 	// Markdowns contain the markdown files you want to display.
 	// The key indicates the file name and must not overlap with the keys.
 	// The value is the content in markdown format.
-	//+kubebuiler:validation:Required
-	//+kubebuiler:validation:MinItems=1
+	//+kubebuilder:validation:Required
 	Markdowns map[string]string `json:"markdowns,omitempty"`
 
 	// Replicas is the number of viewers.

--- a/codes/markdown-view/api/v1/markdownview_types.go
+++ b/codes/markdown-view/api/v1/markdownview_types.go
@@ -28,6 +28,7 @@ type MarkdownViewSpec struct {
 	// The key indicates the file name and must not overlap with the keys.
 	// The value is the content in markdown format.
 	//+kubebuilder:validation:Required
+	//+kubebuilder:validation:MinProperties=1
 	Markdowns map[string]string `json:"markdowns,omitempty"`
 
 	// Replicas is the number of viewers.

--- a/codes/markdown-view/config/crd/bases/view.zoetrope.github.io_markdownviews.yaml
+++ b/codes/markdown-view/config/crd/bases/view.zoetrope.github.io_markdownviews.yaml
@@ -49,6 +49,7 @@ spec:
                 description: Markdowns contain the markdown files you want to display.
                   The key indicates the file name and must not overlap with the keys.
                   The value is the content in markdown format.
+                minProperties: 1
                 type: object
               replicas:
                 default: 1

--- a/codes/tenant/api/v1/tenant_types.go
+++ b/codes/tenant/api/v1/tenant_types.go
@@ -16,14 +16,14 @@ type TenantSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Namespaces are the names of the namespaces that belong to the tenant
-	//+kubebuiler:validation:Required
-	//+kubebuiler:validation:MinItems=1
+	//+kubebuilder:validation:Required
+	//+kubebuilder:validation:MinItems=1
 	Namespaces []string `json:"namespaces"`
 	// NamespacePrefix is the prefix for the name of namespaces
 	//+optional
 	NamespacePrefix string `json:"namespacePrefix,omitempty"`
 	// Admin is the identity with admin for the tenant
-	//+kubebuiler:validation:Required
+	//+kubebuilder:validation:Required
 	Admin rbacv1.Subject `json:"admin"`
 }
 

--- a/codes/tenant/config/crd/bases/multitenancy.example.com_tenants.yaml
+++ b/codes/tenant/config/crd/bases/multitenancy.example.com_tenants.yaml
@@ -68,6 +68,7 @@ spec:
                 description: Namespaces are the names of the namespaces that belong to the tenant
                 items:
                   type: string
+                minItems: 1
                 type: array
             required:
             - admin

--- a/docs/controller-runtime/client.md
+++ b/docs/controller-runtime/client.md
@@ -127,7 +127,7 @@ Patchには`client.MergeFrom`や`client.StrategicMergeFrom`を利用する方法
 `client.MergeFrom`でリストを更新すると指定した要素で上書きされますが、`client.StrategicMergeFrom`ではリストはpatchStrategyに応じて
 要素が追加されたり更新されたりします。
 
-`client.MergeFrom`を利用してDeploymentの利プリカ数のみを更新する例を以下に示します。
+`client.MergeFrom`を利用してDeploymentのレプリカ数のみを更新する例を以下に示します。
 
 [import:"patch-merge"](../../codes/client-sample/main.go)
 

--- a/docs/controller-tools/crd.md
+++ b/docs/controller-tools/crd.md
@@ -106,10 +106,7 @@ type SampleSpec struct {
 
 ### Validation
 
-`Markdowns`フィールドには`// +kubebuiler:validation:MinItems=1`というマーカーが付与されています。
-これは最低1つ以上の要素を記述しないと、カスタムリソースを作成するときにバリデーションエラーとなることを示しています。
-
-`MinItems`以外にも下記のようなバリデーションが用意されています。
+Kubebuilderには`Required`以外にも様々なバリデーションが用意されています。
 詳しくは`controller-gen crd -w`コマンドで確認してください。
 
 - リストの最小要素数、最大要素数


### PR DESCRIPTION
typoの修正をしました
kubebuiler -> kubebuilder

`tenant` の方は `make install` までパスしました

`markdown-view` は `make install` 時に 
`codes/markdown-view/api/v1/markdownview_types.go:32:2: must apply minitems to an array` と出力されました．
`kubebuilder:validation:MinItems` は 配列用で，mapには使用できないようです．
map の場合は `kubebuilder:validation:MinProperties` を使用するように修正し
 `make install`, `make deploy` までパスしました．

https://book.kubebuilder.io/reference/markers/crd-validation.htm