### PR TITLE
fix some minor errors

### DIFF
--- a/codes/tenant/api/v1/tenant_types.go
+++ b/codes/tenant/api/v1/tenant_types.go
@@ -17,7 +17,6 @@ type TenantSpec struct {
 
 	// Namespaces are the names of the namespaces that belong to the tenant
 	//+kubebuiler:validation:Required
-	//+kubebuiler:validation:MinItems=1
 	Namespaces []string `json:"namespaces"`
 	// NamespacePrefix is the prefix for the name of namespaces
 	//+optional

--- a/docs/controller-runtime/client.md
+++ b/docs/controller-runtime/client.md
@@ -127,7 +127,7 @@ Patchには`client.MergeFrom`や`client.StrategicMergeFrom`を利用する方法
 `client.MergeFrom`でリストを更新すると指定した要素で上書きされますが、`client.StrategicMergeFrom`ではリストはpatchStrategyに応じて
 要素が追加されたり更新されたりします。
 
-`client.MergeFrom`を利用してDeploymentの利プリカ数のみを更新する例を以下に示します。
+`client.MergeFrom`を利用してDeploymentのレプリカ数のみを更新する例を以下に示します。
 
 [import:"patch-merge"](../../codes/client-sample/main.go)
 

--- a/docs/controller-tools/crd.md
+++ b/docs/controller-tools/crd.md
@@ -106,10 +106,7 @@ type SampleSpec struct {
 
 ### Validation
 
-`Markdowns`フィールドには`// +kubebuiler:validation:MinItems=1`というマーカーが付与されています。
-これは最低1つ以上の要素を記述しないと、カスタムリソースを作成するときにバリデーションエラーとなることを示しています。
-
-`MinItems`以外にも下記のようなバリデーションが用意されています。
+Kubebuilderには`Required`以外にも様々なバリデーションが用意されています。
 詳しくは`controller-gen crd -w`コマンドで確認してください。
 
 - リストの最小要素数、最大要素数


### PR DESCRIPTION
- fix a typo
- `MinItems` validation can only be used for array. If we use it for
  map, Kubebuilder fails with the following error.

```
..../github.com/satoru-takeuchi/markdown-viewer/api/v1/markdownview_types.go:33:2:
must apply minitems to an array
```

Signed-off-by: Satoru Takeuchi <satoru.takeuchi@gmail.com>