### PR TITLE
chore: update editing kustomization.yaml section of webhook.md

### DIFF
--- a/docs/kubebuilder/webhook.md
+++ b/docs/kubebuilder/webhook.md
@@ -88,7 +88,7 @@ Admission Webhook機能を利用するためには証明書が必要となりま
 Kubebuilderコマンドで生成した直後の状態では、Webhook機能が利用できるようにはなっていません。
 `config/default/kustomization.yaml`ファイルを編集する必要があります。
 
-`config/default/kustomization.yaml`ファイルを開き、以下のように`resources`の`../webhook`と`../certmanager`, `patches`の`manager_webhook_patch.yaml`と`webhookcainjection_patch.yaml`, `replacements`のコメントを外して有効化します。
+`config/default/kustomization.yaml`ファイルを開き、以下のように`resources`の`../certmanager`, `patches`の`webhookcainjection_patch.yaml`, `replacements`のコメントを外して有効化します。
 
 [import](../../codes/00_scaffold/config/default/kustomization.yaml)
 


### PR DESCRIPTION
## Background
In my environment, `../webhook` and `manager_webhook_patch.yaml` is uncommented when I execute `kubebuider create webhook`.
But if it depends on only my environment or there is some mistakes, please feel free to close this PR.

## Procedure
```bash
$ mkdir markdown-view

$ cd markdown-view

$ kubebuilder init --domain ksrnnb.github.io --repo github.com/ksrnnb/markdown-view

$ kubebuilder create api --group view --version v1 --kind MarkdownView

$ make manifests

$ kubebuilder create webhook --group view --version v1 --kind MarkdownView --programmatic-validation --defaulting
```

## Environment
```bash
$ kubebuilder version
Version: main.version{KubeBuilderVersion:"4.1.1", KubernetesVendor:"1.30.0", GitCommit:"e65415f10a6f5708604deca089eee6b165174e5e", BuildDate:"2024-07-23T07:11:14Z", GoOs:"darwin", GoArch:"arm64"}
```